### PR TITLE
Update directory location in hotspot-menu

### DIFF
--- a/hotspot-menu
+++ b/hotspot-menu
@@ -3,7 +3,7 @@
 #main menu for hotspot tools
 #20200221 km4ack
 
-DIR=$HOME/hotspot-tools
+DIR=$HOME/hotspot-tools-lite
 VER=$(cat $DIR/changelog | grep version= | sed 's/version=//')
 
 PS3='Please enter your choice: '


### PR DESCRIPTION
As the repository was renamed, the dir location needs to be adjusted unless you clone it explicitely into its old name. Alternatively, you could set it to `$(pwd)`.